### PR TITLE
Fix YAML header formatting in tutorial vignette

### DIFF
--- a/vignettes/phybaseR_tutorial.Rmd
+++ b/vignettes/phybaseR_tutorial.Rmd
@@ -1,11 +1,10 @@
 ---
 title: "phybaseR: An R package to easily create and run PhyBaSE models
 output: rmarkdown::html_vignette
-vignette: >
+---
   %\VignetteIndexEntry{phybaseR: An R package to easily create and run PhyBaSE models}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
----
 
 ```{r, include = FALSE}
 knitr::opts_chunk$set(


### PR DESCRIPTION
Corrected the YAML header in phybaseR_tutorial.Rmd by removing an extraneous 'vignette: >' line and ensuring proper block closure. This improves compatibility with rmarkdown and vignette processing.