### PR TITLE
Add rmarkdown to VignetteBuilder field

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,4 +31,4 @@ Suggests:
     knitr,
     rmarkdown,
     testthat (>= 3.0.0)
-VignetteBuilder: knitr
+VignetteBuilder: knitr, rmarkdown


### PR DESCRIPTION
Updated the DESCRIPTION file to include rmarkdown in the VignetteBuilder field, allowing vignettes to be built with both knitr and rmarkdown.