### PR TITLE
Update .Rbuildignore and vignette metadata format

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,3 +5,4 @@
 ^Rplots\.pdf$
 ^\.DS_Store$
 ^doc$
+^Meta$

--- a/vignettes/phybaseR_tutorial.Rmd
+++ b/vignettes/phybaseR_tutorial.Rmd
@@ -1,10 +1,10 @@
 ---
 title: "phybaseR: An R package to easily create and run PhyBaSE models"
 output: rmarkdown::html_vignette
-vignette:
-  index: "phybaseR: An R package to easily create and run PhyBaSE models"
-  engine: "knitr::rmarkdown"
-  encoding: "UTF-8"
+vignette: >
+  %\VignetteIndexEntry{phybaseR: An R package to easily create and run PhyBaSE models}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
 ---
 
 ## Introduction


### PR DESCRIPTION
Added '^Meta$' to .Rbuildignore to exclude Meta directory from build. Changed vignette metadata in phybaseR_tutorial.Rmd to use R markdown comment format for compatibility with R vignette processing.