### PR TITLE
Disable DIC/WAIC for single chain runs and add test

### DIFF
--- a/R/phybase_run.R
+++ b/R/phybase_run.R
@@ -499,6 +499,13 @@ phybase_run <- function(
     )
     update(model, n.iter = n.burnin)
 
+    # Disable DIC/WAIC if only 1 chain (rjags requirement)
+    if (n.chains < 2 && (DIC || WAIC)) {
+      warning("DIC and WAIC require at least 2 chains. Disabling calculation.")
+      DIC <- FALSE
+      WAIC <- FALSE
+    }
+
     # Sample posterior
     samples <- rjags::coda.samples(
       model,

--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ The vignette covers:
 -   Handling missing data
 -   Incorporating measurement error
 -   Modeling binary variables
--   Modeling multinomial variables
--   Using latent variables
 -   Using latent variables
 -   Causal model validation with d-separation
 -   Parallel computing for faster MCMC

--- a/tests/repro_summary_issue.R
+++ b/tests/repro_summary_issue.R
@@ -1,0 +1,36 @@
+library(phybaseR)
+library(ape)
+
+# Simulate data
+set.seed(123)
+N <- 50
+tree <- rtree(N)
+data <- data.frame(
+    X = rnorm(N),
+    Y = rnorm(N)
+)
+data$Y <- 0.5 * data$X + rnorm(N)
+
+cat("=== TEST 1: 3 Chains (Should show Rhat and n.eff) ===\n")
+fit3 <- phybase_run(
+    data = data,
+    tree = tree,
+    equations = list(Y ~ X),
+    n.chains = 3,
+    n.iter = 1000,
+    n.burnin = 500,
+    quiet = TRUE
+)
+print(summary(fit3))
+
+cat("\n=== TEST 2: 1 Chain (Should show n.eff, NO Rhat) ===\n")
+fit1 <- phybase_run(
+    data = data,
+    tree = tree,
+    equations = list(Y ~ X),
+    n.chains = 1,
+    n.iter = 1000,
+    n.burnin = 500,
+    quiet = TRUE
+)
+print(summary(fit1))


### PR DESCRIPTION
Added a check in phybase_run to disable DIC and WAIC calculations when only one chain is used, as required by rjags. Updated README to remove duplicate and outdated vignette items. Added a test script to verify summary output for single and multiple chains.