### PR TITLE
Update documentation for phybase functions and datasets

### DIFF
--- a/man/phybase_dsep.Rd
+++ b/man/phybase_dsep.Rd
@@ -25,15 +25,16 @@ If \code{latent} is NULL, returns a list of formulas representing
 This function takes a set of structural equations defining a causal model
 and returns the conditional independence statements (d-separation or m-separation tests)
 implied by the model structure. If latent variables are specified, the function
-uses Shipley's MAG (Maximal Ancestral Graph) approach to account for unmeasured confounders.
+uses the MAG (Maximal Ancestral Graph) approach by Shipley and Douma (2021)
+to account for unmeasured latent variables.
 }
 \details{
 The function implements the basis set approach to d-separation testing
-(Shipley 2000, 2009). For standard DAGs without latent variables, it identifies
+(Shipley 2000, 2009, 2016). For standard DAGs without latent variables, it identifies
 pairs of non-adjacent variables and creates conditional independence tests.
 
 When latent variables are specified, the function uses the DAG-to-MAG conversion
-(Shipley 2016) to identify m-separation statements and induced correlations
+(Shipley & Douma 2021) to identify m-separation statements and induced correlations
 among observed variables that arise from shared latent common causes.
 }
 \examples{
@@ -57,4 +58,9 @@ context. Ecology, 90(2), 363-368.
 
 Shipley, B. (2016). Cause and Correlation in Biology (2nd ed.).
 Cambridge University Press.
+
+Shipley, B., & Douma, J. C. (2021). Testing Piecewise Structural Equations
+Models in the Presence of Latent Variables and Including Correlated Errors.
+Structural Equation Modeling: A Multidisciplinary Journal, 28(4), 582–589.
+https://doi.org/10.1080/10705511.2020.1871355
 }

--- a/man/phybase_model.Rd
+++ b/man/phybase_model.Rd
@@ -27,7 +27,7 @@ If unnamed, it defaults to "se" for all specified variables.
 }}
 
 \item{distribution}{Optional named character vector specifying the distribution for response variables.
-Default is "gaussian" for all variables. Supported values: "gaussian", "binomial".
+Default is "gaussian" for all variables. Supported values: "gaussian", "binomial", "multinomial".
 For "binomial" variables, the model uses a logit link and a Bernoulli likelihood, with phylogenetic correlation modeled on the latent scale.}
 
 \item{vars_with_na}{Optional character vector of response variable names that have missing data.

--- a/man/phybase_run.Rd
+++ b/man/phybase_run.Rd
@@ -44,9 +44,13 @@ phybase_run(
 
 \item{n.thin}{Thinning rate (default = max(1, floor((n.iter - n.burnin) / 1000))).}
 
-\item{DIC}{Logical; whether to compute DIC using \code{dic.samples()} (default = TRUE).}
+\item{DIC}{Logical; whether to compute DIC using \code{dic.samples()} (default = TRUE).
+**Note**: DIC penalty will be inflated for models with measurement error or repeated measures
+because latent variables are counted as parameters (penalty ≈ structural parameters + N).
+For model comparison, use WAIC or compare mean deviance across models with similar structure.}
 
-\item{WAIC}{Logical; whether to sample values for WAIC and deviance (default = FALSE).}
+\item{WAIC}{Logical; whether to sample values for WAIC and deviance (default = FALSE).
+WAIC is generally more appropriate than DIC for hierarchical models with latent variables.}
 
 \item{n.adapt}{Number of adaptation iterations (default = 100).}
 
@@ -54,13 +58,17 @@ phybase_run(
 
 \item{dsep}{Logical; if \code{TRUE}, monitor only the first beta in each structural equation (used for d-separation testing).}
 
-\item{variability}{Optional character vector or named character vector of variable names that have measurement error or within-species variability.
-If named, the names should be the variable names and the values should be the type of variability: "se" (for mean and standard error) or "reps" (for repeated measures).
-If unnamed, the function attempts to infer the type from the data:
-\itemize{
-  \item If \code{Var_se} exists in data, type is "se".
-  \item If \code{Var} is a matrix or \code{Var_obs} exists, type is "reps".
-}}
+\item{variability}{Optional specification for variables with measurement error or within-species variability.
+  **AUTO-DETECTION**: If a variable \code{X} has a corresponding column \code{X_se} (standard errors),
+  \code{X_obs} (repeated measures), or is provided as a matrix, variability is automatically detected.
+
+  **Manual specification** (for non-standard column names):
+  \itemize{
+    \item Simple: \code{list(X = "se", Y = "reps")} - uses standard \code{X_se}/\code{Y_obs} naming
+    \item Custom columns: \code{list(X = list(type = "se", se_col = "X_SD"))} - specify custom column names
+    \item For SE: \code{se_col} (SE column), \code{mean_col} (mean column, optional)
+    \item For reps: \code{obs_col} (observations matrix column)
+  }}
 
 \item{distribution}{Optional named character vector specifying the distribution for response variables.
 Default is "gaussian" for all variables. Supported values: "gaussian", "binomial".

--- a/man/phybase_waic.Rd
+++ b/man/phybase_waic.Rd
@@ -26,8 +26,6 @@ Calculates the Widely Applicable Information Criterion (WAIC) for a fitted PhyBa
 \details{
 This function uses the \code{dic} module in JAGS to monitor \code{WAIC} and \code{deviance}.
 The WAIC is calculated as: \code{WAIC = mean(deviance) + p_waic}.
-Note that for phylogenetic models using multivariate normal distributions, the effective number of parameters
-(\code{p_waic}) may reflect the correlation structure of the data.
 }
 \examples{
 \dontrun{

--- a/man/rhino.dat.Rd
+++ b/man/rhino.dat.Rd
@@ -8,15 +8,15 @@
 A data frame with 100 rows (one per species) and 6 columns:
 \describe{
   \item{SP}{Character. Species names matching the tip labels in rhino.tree}
-  \item{BM}{Numeric. Body mass (log-transformed)}
-  \item{LS}{Numeric. Litter size (log-transformed)}
-  \item{NL}{Numeric. Number of litters per year (log-transformed)}
-  \item{DD}{Numeric. Development duration (log-transformed)}
-  \item{RS}{Numeric. Reproductive seasonality (binary: 0 or 1)}
+  \item{BM}{Numeric. Body mass (standardised)}
+  \item{LS}{Numeric. Litter size (standardised)}
+  \item{NL}{Numeric. Nose length (standardised)}
+  \item{DD}{Numeric. Dispersal distance (standardised)}
+  \item{RS}{Numeric. Range size (standardised)}
 }
 }
 \source{
-Simulated data for von Hardenberg and Gonzalez-Voyer (2025)
+Simulated data for Gonzalez-Voyer & von Hardenberg (2014)
 }
 \usage{
 rhino.dat
@@ -31,11 +31,11 @@ This simulated dataset represents life-history traits for hypothetical
 Rhinograd species. The data can be used to test causal hypotheses about
 life-history evolution using phylogenetic structural equation models.
 
-Example causal model (Model 8 from the README):
+Example causal model (Model 8 from Gonzalez-Voyer and von Hardenberg (2014)):
 \itemize{
   \item Body mass (BM) affects litter size (LS)
-  \item Body mass (BM) and reproductive seasonality (RS) affect number of litters (NL)
-  \item Number of litters (NL) affects development duration (DD)
+  \item Body mass (BM) and range size (RS) affect nose length (NL)
+  \item Nose length (NL) affects dispersal distance (DD)
 }
 }
 \examples{
@@ -45,8 +45,8 @@ summary(rhino.dat)
 
 }
 \references{
-von Hardenberg, A. and Gonzalez-Voyer, A. (2025).
-PhyBaSE: A Bayesian approach to Phylogenetic Structural Equation Models.
-Methods in Ecology and Evolution. https://doi.org/10.1111/2041-210X.70044
+Gonzalez-Voyer, A., & von Hardenberg, A. (2014). An introduction to
+phylogenetic path analysis. In: Modern phylogenetic comparative methods
+and their application in evolutionary biology (pp. 201–229). Springer.
 }
 \keyword{datasets}

--- a/man/rhino.tree.Rd
+++ b/man/rhino.tree.Rd
@@ -9,7 +9,7 @@ A phylo object (from the ape package) with 100 tips and 99 internal nodes.
 The tree has been scaled so that the root age is 1.0.
 }
 \source{
-Simulated data for von Hardenberg and Gonzalez-Voyer (2025)
+Simulated data for Gonzalez-Voyer and von Hardenberg (2014)
 }
 \usage{
 rhino.tree
@@ -20,7 +20,7 @@ This tree is used to demonstrate phylogenetic Bayesian structural equation
 modeling with the phybaseR package.
 }
 \details{
-Rhinograds (nasobames) are hypothetical mammals used as examples in
+Rhinograds  are hypothetical mammals used as examples in
 phylogenetic comparative methods. This simulated tree represents the
 evolutionary relationships among 100 Rhinograd species.
 }
@@ -30,8 +30,8 @@ plot(rhino.tree)
 
 }
 \references{
-von Hardenberg, A. and Gonzalez-Voyer, A. (2025).
-PhyBaSE: A Bayesian approach to Phylogenetic Structural Equation Models.
-Methods in Ecology and Evolution. https://doi.org/10.1111/2041-210X.70044
+Gonzalez-Voyer, A., & von Hardenberg, A. (2014). An introduction to
+phylogenetic path analysis. In: Modern phylogenetic comparative methods
+and their application in evolutionary biology (pp. 201–229). Springer.
 }
 \keyword{datasets}


### PR DESCRIPTION
Revised man pages to clarify references, variable descriptions, and methodology for phybase_dsep, phybase_model, phybase_run, phybase_waic, rhino.dat, and rhino.tree. Updated references to Shipley & Douma (2021) and Gonzalez-Voyer & von Hardenberg (2014), corrected trait and source descriptions, and improved explanations for model options and variability handling.