### PR TITLE
Add dummy ID usage to prevent GLMM warnings

### DIFF
--- a/R/phybase_model.R
+++ b/R/phybase_model.R
@@ -103,7 +103,13 @@ phybase_model <- function(
   param_map <- list()
 
   # Start model
-  model_lines <- c("model {", "  # Structural equations", "  for (i in 1:N) {")
+  model_lines <- c(
+    "model {",
+    "  # Dummy usage of ID to prevent warnings in GLMM-only models",
+    "  dummy_ID <- ID[1,1]",
+    "  # Structural equations",
+    "  for (i in 1:N) {"
+  )
 
   for (j in seq_along(eq_list)) {
     eq <- eq_list[[j]]


### PR DESCRIPTION
Introduces a dummy usage of the ID variable in the model initialization to avoid warnings in GLMM-only models where ID may otherwise be unused.