### PR TITLE
Improve handling of induced correlations and WAIC recompilation

### DIFF
--- a/tests/repro_waic_error.R
+++ b/tests/repro_waic_error.R
@@ -1,0 +1,61 @@
+library(phybaseR)
+
+data("rhino.dat")
+data("rhino.tree")
+
+data_list <- list(
+    BM = rhino.dat$BM,
+    NL = rhino.dat$NL,
+    DD = rhino.dat$DD,
+    LS = rhino.dat$LS,
+    RS = rhino.dat$RS
+)
+
+equations <- list(
+    LS ~ BM,
+    NL ~ BM + RS,
+    DD ~ NL
+)
+
+# Reproduce the user's workflow
+cat("\n=== Running phybase_run (Parallel) ===\n")
+fit_rhino <- phybase_run(
+    data = data_list,
+    tree = rhino.tree,
+    equations = equations,
+    WAIC = FALSE,
+    parallel = TRUE,
+    n.cores = 2,
+    ic_recompile = FALSE, # Force recompilation in phybase_waic
+    n.iter = 1000,
+    n.burnin = 500
+)
+
+cat("\n=== Running phybase_waic with n.burnin=200 ===\n")
+tryCatch(
+    {
+        # We expect recompilation to use this burn-in
+        waic_res <- phybase_waic(fit_rhino, n.burnin = 200)
+        print(waic_res)
+
+        cat("\n=== Checking R-hat ===\n")
+        sum_stats <- summary(fit_rhino)
+
+        if (is.matrix(sum_stats) || is.data.frame(sum_stats)) {
+            if ("Rhat" %in% colnames(sum_stats)) {
+                cat("\nR-hat column found in summary statistics!\n")
+                print(head(sum_stats[, "Rhat"]))
+            } else {
+                cat(
+                    "\nWARNING: R-hat column NOT found in summary statistics.\n"
+                )
+            }
+        } else {
+            print(head(sum_stats$statistics))
+        }
+    },
+    error = function(e) {
+        cat("\nERROR CAUGHT:\n")
+        print(e)
+    }
+)

--- a/tests/test_latent_mag_fix.R
+++ b/tests/test_latent_mag_fix.R
@@ -1,0 +1,42 @@
+library(phybaseR)
+
+# Simulate bovids data for testing
+set.seed(123)
+n <- 50
+
+bovids.data <- list(
+    BR = rnorm(n),
+    BM = rnorm(n),
+    S = rnorm(n),
+    G = rnorm(n),
+    L = rnorm(n)
+)
+
+# Create a simple tree
+bovidsCut.tree <- ape::rtree(n)
+
+# User's equations with latent variable
+bovids.equations_lat <- list(BR ~ Lat, BM ~ Lat, S ~ BM, G ~ BR, L ~ BR)
+
+cat("\n=== Testing MAG Latent Variable Fix ===\n")
+tryCatch(
+    {
+        fit_bovids_CB2_lat <- phybase_run(
+            data = bovids.data,
+            tree = bovidsCut.tree,
+            equations = bovids.equations_lat,
+            n.iter = 1000,
+            n.burnin = 500,
+            latent = c("Lat"),
+            WAIC = FALSE,
+            parallel = FALSE # Start with sequential for debugging
+        )
+
+        cat("\n✓ Model fitted successfully!\n")
+        print(summary(fit_bovids_CB2_lat))
+    },
+    error = function(e) {
+        cat("\n✗ ERROR:\n")
+        print(e)
+    }
+)


### PR DESCRIPTION
Enhanced phybase_run to add intercept-only models for variables involved in induced correlations but not present as response variables in equations. Updated phybase_waic to use the user-specified n.burnin during model recompilation and improved chain handling. Added tests to reproduce WAIC error and verify latent variable fixes.