### PR TITLE
Update beta parameter naming in params_to_monitor

### DIFF
--- a/R/phybase_run.R
+++ b/R/phybase_run.R
@@ -786,7 +786,7 @@ phybase_run <- function(
               # Standard continuous predictor
               params_to_monitor <- c(
                 params_to_monitor,
-                paste0("beta", predictor)
+                paste0("beta_", response, "_", predictor)
               )
             }
           }
@@ -832,7 +832,10 @@ phybase_run <- function(
 
           if (!is_categorical) {
             # Standard continuous predictor
-            params_to_monitor <- c(params_to_monitor, paste0("beta", predictor))
+            params_to_monitor <- c(
+              params_to_monitor,
+              paste0("beta_", response, "_", predictor)
+            )
           }
         }
 


### PR DESCRIPTION
Changed the naming convention for beta parameters added to params_to_monitor from 'beta{predictor}' to 'beta_{response}_{predictor}' for improved clarity and consistency.