### PR TITLE
Set autoburnin=FALSE in gelman.diag call

### DIFF
--- a/R/phybase_run.R
+++ b/R/phybase_run.R
@@ -1320,7 +1320,13 @@ phybase_run <- function(
   if (n.chains > 1) {
     tryCatch(
       {
-        gelman_diag <- coda::gelman.diag(samples, multivariate = FALSE)
+        # Use autoburnin=FALSE to avoid discarding half the chain (we already burned in)
+        # Use transform=TRUE generally helps, but can be problematic for constant vars
+        gelman_diag <- coda::gelman.diag(
+          samples,
+          multivariate = FALSE,
+          autoburnin = FALSE
+        )
         psrf <- gelman_diag$psrf
 
         # Add R-hat to summary statistics


### PR DESCRIPTION
Updated the gelman.diag function to use autoburnin=FALSE, ensuring that no additional burn-in is applied since burn-in has already been performed. This change prevents discarding half the chain and improves convergence diagnostics.