### PR TITLE
Fix function name in getting started vignette

### DIFF
--- a/vignettes/01_getting_started.Rmd
+++ b/vignettes/01_getting_started.Rmd
@@ -126,7 +126,7 @@ plot(fit$samples)
 
 `fit$samples` is an MCMC object, so you can use all coda functions to analyze and plot the MCMC samples.
 
-You can see how `o0aqsw0-we3phybase_run()` translates your model into JAGS syntax calling `fit$model` or, before fitting it, using `phybase_model()`:
+You can see how `phybase_run()` translates your model into JAGS syntax calling `fit$model` or, before fitting it, using `phybase_model()`:
 ```{r}
 # Generate JAGS model code
 jags_model_code <- phybase_model(


### PR DESCRIPTION
Corrected the function name from `o0aqsw0-we3phybase_run()` to `phybase_run()` in the documentation to accurately reflect the intended usage.