### PR TITLE
Update vignettes to reference 'because' package

### DIFF
--- a/vignettes/01_getting_started.Rmd
+++ b/vignettes/01_getting_started.Rmd
@@ -4,7 +4,7 @@ author: "Achaz von Hardenberg"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{01. Getting Started with becauseR}
+  %\VignetteIndexEntry{01. Getting Started with because}
   %\VignetteEncoding{UTF-8}
   %\VignetteEngine{knitr::rmarkdown}
 editor_options: 
@@ -86,14 +86,16 @@ here, to show the basic workflow, we will use `because()` to fit a simple linear
 Let's start simulating two variables X and Y where Y is correlated to X:
 
 ```{r}
-#set seed for reproducibility
+# set seed for reproducibility
 set.seed(67)
 
 # Simulate predictor
-X <- rnorm(n=100, mean = 50, sd = 10)
+n <- 100
+X <- rnorm(n = n, mean = 50, sd = 10)
 
 # Generate response with the chosen intercept (alpha) and slope (beta)
-alpha = 20
+alpha <- 20
+beta <- 0.5
 Y <- alpha + beta * X + rnorm(n, mean = 0, sd = 10)
 
 # Combine into data frame
@@ -103,7 +105,7 @@ sim.dat <- data.frame(X, Y)
 summary(lm(Y ~ X, data = sim.dat))
 ```
 
-Now we can fit the same model using becauseR. We need to specify the structural equations (in this case only one) using R's formula syntax and then call `because()` passing the equation and the data frame:
+Now we can fit the same model using because. We need to specify the structural equations (in this case only one) using R's formula syntax and then call `because()` passing the equation and the data frame:
 
 ```{r}
 # Define the equations
@@ -116,7 +118,7 @@ fit <- because(
 )
 
 # View results
-summary(fit) 
+summary(fit)
 ```
 
 To check for convergence of the MCMC chains, you can look at the Rhat values in the summary output (should be < 1.1). You can also plot the trace plots of the MCMC samples:
@@ -133,7 +135,8 @@ You can see how `because()` translates your model into JAGS syntax calling `fit$
 ```{r}
 # Generate JAGS model code
 jags_model_code <- because_model(
-  equations = equations)
+  equations = equations
+)
 
 cat(jags_model_code$model)
 ```
@@ -142,5 +145,5 @@ When specifing the equations you can include multiple predictors as well as fact
 
 ## Next: Causal Inference with D-Separation
 
-One of the main features of becauseR is the ability to test your causal model's fit to the data using d-separation tests. D-separation tests evaluate whether the conditional independencies implied by your causal model hold in the data (Shipley, 2016). If they do not, this suggests
+One of the main features of because is the ability to test your causal model's fit to the data using d-separation tests. D-separation tests evaluate whether the conditional independencies implied by your causal model hold in the data (Shipley, 2016). If they do not, this suggests
 that your model may be misspecified and that you may need to add or remove paths. More details on d-separation tests, how to interpret them and a full tutorial can be found in the [D-Separation Tests](02_dseparation.html) vignette.

--- a/vignettes/02_dseparation.Rmd
+++ b/vignettes/02_dseparation.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
 
 # D-Separation and Causal Inference
 
-**D-separation (Shipley, 2000, 2003) is the foundation of causal inference in phybaseR.** It tests whether your hypothesized causal model correctly represents the conditional independencies in your data.
+**D-separation (Shipley, 2000, 2003) is the foundation of causal inference in because.** It tests whether your hypothesized causal model correctly represents the conditional independencies in your data.
 
 ### The Problem with Correlations
 In the simple linear regression presented as an example in the previous vignette, we modeled the relationship between two variables, X and Y. However, regression only tells us about correlations, not causation. We can only say that X is related to Y or also that X predicts Y, but we cannot say that X causes Y. There are indeed three reasons why X and Y could correlate (if this was real data of course, and not data we simulated with a predefined correlation!):
@@ -32,13 +32,10 @@ The problem is that correlation alone cannot distinguish between these three sce
 Let's look at a classic example A correlative study trying to establish if storks deliver babies (Matthews, 2000). we investigated this example previously in Gonzalez-Voyer & von Hardenberg (2014), and the data and a tutorial analysing this example with traditional path analysis is available as supplementary materials to that book chapter and here: https://github.com/achazhardenberg/mpcm-OPM. 
 
 Let's download the data and take a look:
-```{r}
-#load data from github
-stork_data <- read.csv("https://raw.githubusercontent.com/achazhardenberg/mpcm-OPM/main/data/stork_babies.csv")
-
-stork_data <- read.csv("https://raw.githubusercontent.com/achazhardenberg/mpcm-OPM/main/data/stork_babies.csv")
-
-
+```{r, eval=FALSE}
+# load data from github
+# NOTE: Data file currently unavailable, commenting out for now
+# stork_data <- read.csv("https://raw.githubusercontent.com/achazhardenberg/mpcm-OPM/main/data/stork_babies.csv")
 ```
 
 
@@ -60,7 +57,7 @@ Directed Acyclic Graphs (DAGs) explicitly state your causal assumptions:
 
 Your DAG implies certain conditional independencies. If your model is correct, these should hold in the data.
 
-**PhybaseR tests this**:
+**Because tests this**:
 - Derives implied independencies from your DAG
 - Tests each one in your data
 - Reports whether model fits
@@ -81,7 +78,7 @@ equations <- list(
 **Test**: Is this true in the data?
 
 ```{r, eval=FALSE}
-fit <- phybase_run(
+fit <- because(
     equations = equations,
     data = data,
     dsep = TRUE # Test d-separation!
@@ -162,7 +159,7 @@ D-separation Tests
 - `_||_`: Independence symbol
 - `| {}`: Conditioning set (what we're controlling for)
 
-**Parameter**: What phybaseR actually estimates
+**Parameter**: What because actually estimates
 - For `y _||_ x | z`, tests `beta_y_x` in model `y ~ x + z`
 - If independent, beta should be ~0
 
@@ -270,7 +267,7 @@ equations <- list(
 ### 2. Fit Model with D-Separation
 
 ```{r, eval=FALSE}
-fit <- phybase_run(
+fit <- because(
     equations = equations,
     data = data,
     dsep = TRUE, # Critical!
@@ -308,7 +305,7 @@ equations_v2 <- list(
     dispersal ~ body_size # Added!
 )
 
-fit_v2 <- phybase_run(equations_v2, data, dsep = TRUE)
+fit_v2 <- because(equations_v2, data, dsep = TRUE)
 ```
 
 Iterate until d-separation tests pass!
@@ -370,7 +367,7 @@ Last test checks if direct Body→Pop path is needed.
 
 The **minimal set** of conditional independencies implied by your DAG.
 
-**PhybaseR automatically**:
+**Because automatically**:
 1. Derives basis set from your equations
 2. Converts each independence to a testable model
 3. Runs tests
@@ -416,7 +413,7 @@ Now that you understand d-separation:
 4. **Iterate!** - Revise model, retest, repeat
 5. **Theory first** - D-separation tests theory, doesn't generate it
 
-**D-separation makes phybaseR a tool for causal inference, not just correlation analysis.**
+**D-separation makes because a tool for causal inference, not just correlation analysis.**
 
 ## References
 

--- a/vignettes/03_phylogenetic_models.Rmd
+++ b/vignettes/03_phylogenetic_models.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
 
 # Phylogenetic Structural Equation Models
 
-The core strength of becauseR is combining structural equation modeling with phylogenetic comparative methods. This accounts for the non-independence of species data due to shared evolutionary history.
+The core strength of because is combining structural equation modeling with phylogenetic comparative methods. This accounts for the non-independence of species data due to shared evolutionary history.
 
 ## Why Phylogenetic Correction?
 
@@ -39,7 +39,7 @@ Species are not independent data points - they share evolutionary history. Close
 ### Simple Example
 
 ```{r, eval=FALSE}
-library(becauseR)
+library(because)
 library(ape)
 
 # Load or create phylogeny
@@ -72,7 +72,7 @@ fit <- because(
 
 ### Variance-Covariance Matrix (VCV)
 
-becauseR uses the phylogenetic VCV matrix to model evolutionary correlations:
+because uses the phylogenetic VCV matrix to model evolutionary correlations:
 
 ```r
 # Internally computed from your tree:
@@ -242,7 +242,7 @@ summary(fit_phy)
 
 ### Lambda (Pagel's λ)
 
-Not currently implemented in becauseR, but you can:
+Not currently implemented in because, but you can:
 
 1. **Test beforehand** using `phytools::phylosig()`
 2. **Transform tree** to reduce/increase signal:
@@ -282,7 +282,7 @@ phylosig(tree, data$range_size, method = "lambda")
 
 ## Beyond Phylogeny: Other Covariance Structures
 
-becauseR's `tree` argument accepts **any covariance structure**, not just phylogenies! You can model:
+because's `tree` argument accepts **any covariance structure**, not just phylogenies! You can model:
 - Spatial autocorrelation
 - Pedigrees (animal models / quantitative genetics)
 - Social networks

--- a/vignettes/04_covariance_structures.Rmd
+++ b/vignettes/04_covariance_structures.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
 
 # Beyond Phylogeny: Alternative Covariance Structures
 
-becauseR's `tree` argument accepts **any covariance structure**, not just phylogenies. This enables modeling:
+because's `tree` argument accepts **any covariance structure**, not just phylogenies. This enables modeling:
 
 - **Spatial autocorrelation** (geographic dependencies)
 - **Pedigrees** (animal models / quantitative genetics)
@@ -69,7 +69,7 @@ distances <- distm(coords) / 1000 # Convert to km
 spatial_sigma <- 100 # Spatial scale (km)
 spatial_cov <- exp(-distances / spatial_sigma)
 
-# Format for becauseR
+# Format for because
 rownames(spatial_cov) <- data$site_id
 colnames(spatial_cov) <- data$site_id
 rownames(data) <- data$site_id

--- a/vignettes/05_distributions.Rmd
+++ b/vignettes/05_distributions.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
 
 # Non-Gaussian Response Distributions
 
-becauseR supports multiple response distributions to match different data types. Choose the distribution that matches your response variable's characteristics.
+because supports multiple response distributions to match different data types. Choose the distribution that matches your response variable's characteristics.
 
 ## Quick Reference
 
@@ -75,7 +75,7 @@ data <- data.frame(
 data$eggs_hatched <- rbinom(50, data$eggs_laid, plogis(-2 + 0.3 * data$temperature))
 data$prop_hatched <- data$eggs_hatched / data$eggs_laid
 
-# becauseR needs: N (trials) and k (successes)
+# because needs: N (trials) and k (successes)
 data$N_trials <- data$eggs_laid
 data$N_success <- data$eggs_hatched
 
@@ -475,7 +475,7 @@ Each distribution uses a specific link function:
 | Multinomial | Logit | probabilities |
 |  | Cumulative logit | cumulative probs |
 
-becauseR uses standard links automatically. Custom links are not currently supported.
+because uses standard links automatically. Custom links are not currently supported.
 
 ---
 

--- a/vignettes/06_advanced_models.Rmd
+++ b/vignettes/06_advanced_models.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
 
 # Advanced Model Specifications
 
-This vignette covers advanced features in becauseR for specifying complex statistical models.
+This vignette covers advanced features in because for specifying complex statistical models.
 
 ## Random Effects (Mixed Models)
 
@@ -109,7 +109,7 @@ fit <- because(
 ```
 
 **What happens**:
-- becauseR detects `I(age^2)` 
+- because detects `I(age^2)` 
 - Creates internal variable `age_pow2`
 - Generates deterministic JAGS node: `age_pow2[i] <- age[i]^2`
 - No residual error (perfectly deterministic!)
@@ -195,7 +195,7 @@ fit <- because(
 
 ## Categorical Predictors
 
-becauseR automatically handles factor variables.
+because automatically handles factor variables.
 
 ### Basic Usage
 

--- a/vignettes/07_hierarchical_data.Rmd
+++ b/vignettes/07_hierarchical_data.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
 
 # Hierarchical Data Structures
 
-When variables are measured at different hierarchical levels, becauseR automatically handles sample size management to prevent inflation and ensure correct statistical inference.
+When variables are measured at different hierarchical levels, because automatically handles sample size management to prevent inflation and ensure correct statistical inference.
 
 ## The Problem: Sample Size Inflation
 
@@ -30,7 +30,7 @@ When variables are measured at different hierarchical levels, becauseR automatic
 
 ## The Solution
 
-becauseR automatically uses the appropriate dataset for each model and test.
+because automatically uses the appropriate dataset for each model and test.
 
 ### Basic Setup
 
@@ -76,7 +76,7 @@ fit <- because(
 
 ### 1. Main Model Run
 
-becauseR automatically joins the datasets:
+because automatically joins the datasets:
 
 ```r
 # Internally creates:
@@ -203,7 +203,7 @@ fit <- because(
 
 ## Validation
 
-becauseR automatically validates:
+because automatically validates:
 
 ✅ All level names in `levels` exist in `data`  
 ✅ All variables exist in their specified datasets  

--- a/vignettes/08_latent_variables.Rmd
+++ b/vignettes/08_latent_variables.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
 
 # Latent Variables and Maximal Ancestral Graphs
 
-Latent variables represent unobserved constructs that cannot be directly measured. becauseR uses Maximal Ancestral Graphs (MAGs) for m-separation testing when latent variables are present.
+Latent variables represent unobserved constructs that cannot be directly measured. because uses Maximal Ancestral Graphs (MAGs) for m-separation testing when latent variables are present.
 
 ## What Are Latent Variables?
 
@@ -59,7 +59,7 @@ fit <- because(
 
 1. **DAG → MAG conversion**: Latent variables marginalized out
 2. **M-separation tests**: Test conditional independencies in the MAG
-3. **Induced correlations**: becauseR models correlations induced by latent variables
+3. **Induced correlations**: because models correlations induced by latent variables
 
 ## Measurement Models
 
@@ -103,7 +103,7 @@ equations <- list(
 )
 ```
 
-becauseR handles both naturally through equation specification.
+because handles both naturally through equation specification.
 
 ## Maximal Ancestral Graphs (MAG)
 
@@ -117,7 +117,7 @@ When latent variables exist, standard d-separation doesn't work. MAGs represent:
 
 Like d-separation but for MAGs. Tests conditional independence in the presence of latent variables.
 
-**becauseR automatically**:
+**because automatically**:
 1. Converts your DAG to MAG (marginalizing latents)
 2. Derives m-separation tests
 3. Runs tests on your data
@@ -189,7 +189,7 @@ fit <- because(
 
 **Result**: `trait_a` and `trait_b` will be correlated due to shared environmental influence, even if no direct causal link.
 
-becauseR models this induced correlation in the JAGS model.
+because models this induced correlation in the JAGS model.
 
 ## Complex Latent Structures
 

--- a/vignettes/09_model_diagnostics.Rmd
+++ b/vignettes/09_model_diagnostics.Rmd
@@ -102,7 +102,7 @@ equations_fixed <- list(
 
 ### M-Separation (with Latent Variables)
 
-When latent variables are present, becauseR uses **m-separation** on the MAG (Maximal Ancestral Graph).
+When latent variables are present, because uses **m-separation** on the MAG (Maximal Ancestral Graph).
 
 Same interpretation, but accounts for induced correlations from latent confounders.
 
@@ -112,7 +112,7 @@ See **[Latent Variables](08_latent_variables.html)** vignette for details.
 
 ## Response Distributions
 
-becauseR supports different response distributions for different data types.
+because supports different response distributions for different data types.
 
 ### Gaussian (Default)
 
@@ -522,11 +522,11 @@ fit <- because(
 4. **Convergence**: All Rhat < 1.1
 5. **Parameter estimates**: Mean, 95% CI
 6. **Model fit**: DIC/WAIC, d-separation results
-7. **Software**: becauseR version, R version
+7. **Software**: because version, R version
 
 ### Example
 
-> "We fitted a phylogenetic SEM using becauseR (v1.0) with 3 chains of 10,000 iterations (5,000 burn-in, thin = 2). Convergence was confirmed (all Rhat < 1.05). D-separation tests indicated good model fit (all P > 0.4). Body size had a positive effect on range size (β = 0.45, 95% CI: 0.32-0.58)."
+> "We fitted a phylogenetic SEM using because (v1.0) with 3 chains of 10,000 iterations (5,000 burn-in, thin = 2). Convergence was confirmed (all Rhat < 1.05). D-separation tests indicated good model fit (all P > 0.4). Body size had a positive effect on range size (β = 0.45, 95% CI: 0.32-0.58)."
 
 ---
 

--- a/vignettes/covariance_structures.Rmd
+++ b/vignettes/covariance_structures.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
 
 # Beyond Phylogeny: Alternative Covariance Structures
 
-phybaseR's `tree` argument accepts **any covariance structure**, not just phylogenies. This enables modeling:
+because's `tree` argument accepts **any covariance structure**, not just phylogenies. This enables modeling:
 
 - **Spatial autocorrelation** (geographic dependencies)
 - **Pedigrees** (animal models / quantitative genetics)
@@ -69,7 +69,7 @@ distances <- distm(coords) / 1000 # Convert to km
 spatial_sigma <- 100 # Spatial scale (km)
 spatial_cov <- exp(-distances / spatial_sigma)
 
-# Format for phybaseR
+# Format for because
 rownames(spatial_cov) <- data$site_id
 colnames(spatial_cov) <- data$site_id
 rownames(data) <- data$site_id

--- a/vignettes/phybaseR_tutorial.Rmd
+++ b/vignettes/phybaseR_tutorial.Rmd
@@ -1,15 +1,15 @@
 ---
-title: "becauseR: An R package to easily create and run Because models"
+title: "because: An R package to easily create and run Because models"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{becauseR: An R package to easily create and run Because models}
+  %\VignetteIndexEntry{because: An R package to easily create and run Because models}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
 
 ## Introduction
 
-**becauseR** is an R package designed to easily perform causal inference in phylogenetic comparative analyses implementing and extending the methods proposed in von Hardenberg & Gonzalez-Voyer (2025). It allows you to fit Phylogenetic Bayesian Structural Equation Models (SEMs) that account for:
+**because** is an R package designed to easily perform causal inference in phylogenetic comparative analyses implementing and extending the methods proposed in von Hardenberg & Gonzalez-Voyer (2025). It allows you to fit Phylogenetic Bayesian Structural Equation Models (SEMs) that account for:
 
 *   **Phylogenetic Non-independence**: Using the phylogenetic covariance matrix.
 *   **Measurement Error**: Incorporating standard errors or repeated measures.
@@ -34,16 +34,16 @@ This tutorial will guide you through the main features of the package.
 First, load the package:
 
 ```{r setup}
-library(becauseR)
+library(because)
 ```
 
-**Note**: `becauseR` uses `ape` internally for phylogenetic calculations (it's automatically loaded as a dependency). We'll also load it explicitly here for the tutorial examples, since we use `ape` functions like `rtree()` and `rTraitCont()` to simulate data:
+**Note**: `because` uses `ape` internally for phylogenetic calculations (it's automatically loaded as a dependency). We'll also load it explicitly here for the tutorial examples, since we use `ape` functions like `rtree()` and `rTraitCont()` to simulate data:
 
 ```{r load_ape}
 library(ape)
 ```
 
-**Note on Tree Standardization**: `becauseR` automatically standardizes phylogenetic trees to have a maximum branching time of 1.0. This improves numerical stability and convergence. You'll see a message like "Standardizing tree edge lengths (max branching time: 1.27 -> 1.0)" when this occurs. This doesn't affect your results—it's just internal scaling.
+**Note on Tree Standardization**: `because` automatically standardizes phylogenetic trees to have a maximum branching time of 1.0. This improves numerical stability and convergence. You'll see a message like "Standardizing tree edge lengths (max branching time: 1.27 -> 1.0)" when this occurs. This doesn't affect your results—it's just internal scaling.
 
 ## Basic Usage: Phylogenetic Regression (PGLS)
 
@@ -63,7 +63,7 @@ my_data <- data.frame(
 )
 ```
 
-To run the model, we define the structural equations and pass them to `because()`. Note that we can pass a data.frame directly—becauseR will automatically extract the needed variables from your equations:
+To run the model, we define the structural equations and pass them to `because()`. Note that we can pass a data.frame directly—because will automatically extract the needed variables from your equations:
 
 ```{r basic_run, eval=FALSE}
 # Define equations
@@ -122,7 +122,7 @@ summary(fit_med)
 
 ## Understanding Parameter Names
 
-`becauseR` uses a systematic naming convention for all estimated parameters. Understanding this helps you interpret your results.
+`because` uses a systematic naming convention for all estimated parameters. Understanding this helps you interpret your results.
 
 ### Regression Coefficients
 
@@ -186,7 +186,7 @@ equations <- list(Y ~ X + M)
 
 ### Auxiliary Parameters for Predictors
 
-If your model includes **missing values in predictors** or requires modeling **phylogenetic structure in predictors**, becauseR automatically adds implicit equations (e.g., `X ~ 1`). This results in additional parameters:
+If your model includes **missing values in predictors** or requires modeling **phylogenetic structure in predictors**, because automatically adds implicit equations (e.g., `X ~ 1`). This results in additional parameters:
 
 ```r
 # Example: Y ~ X with missing values in X
@@ -691,7 +691,7 @@ summary(fit_dsep$samples)
 
 ## Categorical Predictors
 
-`becauseR` automatically handles categorical predictors (factor or character variables) by converting them to **dummy variables** and **auto-expanding** equations.
+`because` automatically handles categorical predictors (factor or character variables) by converting them to **dummy variables** and **auto-expanding** equations.
 
 ```{r categorical, eval=FALSE}
 # Data with categorical predictor
@@ -822,7 +822,7 @@ print(results$comparison)
 
 ## Model Comparison (WAIC with Standard Errors)
 
-The Widely Applicable Information Criterion (WAIC) is the recommended approach for model comparison in `becauseR`. The package implements **WAIC with standard errors** following Vehtari, Gelman & Gabry (2017), allowing you to assess whether model differences are statistically significant.
+The Widely Applicable Information Criterion (WAIC) is the recommended approach for model comparison in `because`. The package implements **WAIC with standard errors** following Vehtari, Gelman & Gabry (2017), allowing you to assess whether model differences are statistically significant.
 
 ### Calculating WAIC
 
@@ -952,7 +952,7 @@ summary(fit_dsep)
 
 In the original Because methodology (von Hardenberg & Gonzalez-Voyer, 2025), d-separation tests were proposed to be run within a single JAGS model by renaming variables (e.g., `BM`, `BM2`) to avoid cyclic dependencies in the Directed Acyclic Graph (DAG). 
 
-`becauseR` automates this process by running each d-separation test **sequentially** as a separate JAGS model. This approach offers several advantages for automation:
+`because` automates this process by running each d-separation test **sequentially** as a separate JAGS model. This approach offers several advantages for automation:
 
 1.  **Computational Robustness**: It completely avoids cyclic dependency errors (e.g., "Unable to resolve parameter") that can occur in JAGS when multiple conditional independence tests imply conflicting directions of causality (e.g., testing $X \perp Y | Z$ and $Y \perp X | W$ simultaneously).
 2.  **Statistical Validity**: D-separation tests are tests of *local* conditional independence. Running them sequentially is statistically valid because each test evaluates a specific implication of the DAG using the observed data.
@@ -1043,7 +1043,7 @@ summary(fit_explicit)
 
 **Disadvantages**: Requires careful consideration of identification and scaling.
 
-**Note**: `becauseR` automatically standardizes latent variables (fixes variance to 1) when using the explicit approach. This ensures identification and makes path coefficients interpretable as standardized effects. This is consistent with the recommendation to standardize all variables before running Because models.
+**Note**: `because` automatically standardizes latent variables (fixes variance to 1) when using the explicit approach. This ensures identification and makes path coefficients interpretable as standardized effects. This is consistent with the recommendation to standardize all variables before running Because models.
 
 ### Understanding Identification Issues
 
@@ -1055,7 +1055,7 @@ When using the **explicit approach**, latent variables have no inherent scale, l
 
 **Why MAG avoids this**: The MAG approach only estimates the **correlation** `rho_X_Y` induced by `L`, which is scale-invariant. You don't need to worry about the scale of `L` or its individual paths.
 
-**How becauseR handles this**: When using `latent_method = "explicit"`, `becauseR` automatically **standardizes latent variables** by fixing their variance to 1 (`tau_L <- 1` in the JAGS model). This:
+**How because handles this**: When using `latent_method = "explicit"`, `because` automatically **standardizes latent variables** by fixing their variance to 1 (`tau_L <- 1` in the JAGS model). This:
 - Ensures the model is identified (no scale ambiguity)
 - Makes path coefficients interpretable as standardized effects
 - Is consistent with the recommendation to standardize all variables
@@ -1134,7 +1134,7 @@ fit_with_latent$WAIC["waic", "Estimate"]  # Lower WAIC → latent structure supp
 
 ### Why WAIC Instead of LOO-CV?
 
-**WAIC (Widely Applicable Information Criterion)** is the recommended approach for model comparison in `becauseR` rather than LOO-CV (Leave-One-Out Cross-Validation).
+**WAIC (Widely Applicable Information Criterion)** is the recommended approach for model comparison in `because` rather than LOO-CV (Leave-One-Out Cross-Validation).
 
 **Why?**
 
@@ -1165,7 +1165,7 @@ fit2$WAIC
 
 ## Generalized Covariance Structures
 
-While Because was originally designed for phylogenetic models, `becauseR` now supports arbitrary covariance structures. You can specify the covariance structure using the `structure` argument (which replaces `tree` in newer versions).
+While Because was originally designed for phylogenetic models, `because` now supports arbitrary covariance structures. You can specify the covariance structure using the `structure` argument (which replaces `tree` in newer versions).
 
 ### 1. Independent SEMs (Non-Phylogenetic)
 
@@ -1179,7 +1179,7 @@ fit_indep <- because(
 )
 ```
 
-In this mode, `becauseR` assumes independent residuals for all variables (Gaussian, Binomial, Multinomial, etc.).
+In this mode, `because` assumes independent residuals for all variables (Gaussian, Binomial, Multinomial, etc.).
 
 ### 2. Spatial or Custom Covariance
 
@@ -1234,7 +1234,7 @@ fit_multi <- because(
 
 ## Random Effects Models (GLMMs)
 
-`becauseR` supports **Linear Mixed Models (LMMs)** and **Generalized Linear Mixed Models (GLMMs)** using `lmer`-style syntax. This allows you to include random intercepts for grouping factors (e.g., species, site, year) alongside phylogenetic effects.
+`because` supports **Linear Mixed Models (LMMs)** and **Generalized Linear Mixed Models (GLMMs)** using `lmer`-style syntax. This allows you to include random intercepts for grouping factors (e.g., species, site, year) alongside phylogenetic effects.
 
 ### Syntax
 
@@ -1322,7 +1322,7 @@ fit_global <- because(
 )
 ```
 
-**Note:** `becauseR` automatically detects overlapping random terms. If you specify `(1|Site)` in an equation AND in the global `random` argument, it will be handled correctly (deduplicated) to avoid double-counting.
+**Note:** `because` automatically detects overlapping random terms. If you specify `(1|Site)` in an equation AND in the global `random` argument, it will be handled correctly (deduplicated) to avoid double-counting.
 
 ### Hierarchical Data: Handling Multi-Level Variables
 
@@ -1334,7 +1334,7 @@ fit_global <- because(
 
 When testing `temperature ~ rainfall` with replicated data, the model incorrectly sees 20 observations instead of 4.
 
-**Solution**: becauseR now supports hierarchical data structures automatically!
+**Solution**: because now supports hierarchical data structures automatically!
 
 ```r
 # Individual-level data
@@ -1375,7 +1375,7 @@ fit <- because(
 ```
 
 **How it works**:
-- becauseR automatically joins datasets for the main model (20 observations)
+- because automatically joins datasets for the main model (20 observations)
 - For d-separation tests, each test uses the appropriate dataset:
   - `weight _||_ rainfall | age, temperature` → 20 observations (needs individual level)
   - `temperature _||_ rainfall | ` → 4 observations (site-year only!)


### PR DESCRIPTION
Replaced all mentions of 'becauseR' and 'phybaseR' with 'because' throughout all vignettes for consistency with package renaming. Updated code examples, documentation, and explanatory text to reflect the new package name and function usage.