### PR TITLE
Set eval = FALSE for code chunks in vignettes

### DIFF
--- a/vignettes/01_getting_started.Rmd
+++ b/vignettes/01_getting_started.Rmd
@@ -13,9 +13,10 @@ editor_options:
 ---
 
 ```{r setup, include = FALSE}
-knitr::opts_chunk$set(
+knitr::opts_chunk_set(
   collapse = TRUE,
-  comment = "#>"
+  comment = "#>",
+  eval = FALSE
 )
 ```
 
@@ -88,6 +89,8 @@ Let's start simulating two variables X and Y where Y is correlated to X:
 ```{r}
 # set seed for reproducibility
 set.seed(67)
+library(because)
+
 
 # Simulate predictor
 n <- 100

--- a/vignettes/02_dseparation.Rmd
+++ b/vignettes/02_dseparation.Rmd
@@ -12,7 +12,8 @@ vignette: >
 ```{r setup, include = FALSE}
 knitr::opts_chunk$set(
     collapse = TRUE,
-    comment = "#>"
+    comment = "#>",
+    eval = FALSE
 )
 ```
 
@@ -34,7 +35,9 @@ Let's look at a classic example A correlative study trying to establish if stork
 Let's download the data and take a look:
 ```{r}
 # load data
+library(because)
 data("storks.dat")
+
 # rename to stork_data for consistency with rest of vignette
 stork_data <- storks.dat
 ```

--- a/vignettes/03_phylogenetic_models.Rmd
+++ b/vignettes/03_phylogenetic_models.Rmd
@@ -12,7 +12,8 @@ vignette: >
 ```{r setup, include = FALSE}
 knitr::opts_chunk$set(
     collapse = TRUE,
-    comment = "#>"
+    comment = "#>",
+    eval = FALSE
 )
 ```
 

--- a/vignettes/04_covariance_structures.Rmd
+++ b/vignettes/04_covariance_structures.Rmd
@@ -12,7 +12,8 @@ vignette: >
 ```{r setup, include = FALSE}
 knitr::opts_chunk$set(
     collapse = TRUE,
-    comment = "#>"
+    comment = "#>",
+    eval = FALSE
 )
 ```
 

--- a/vignettes/05_distributions.Rmd
+++ b/vignettes/05_distributions.Rmd
@@ -12,7 +12,8 @@ vignette: >
 ```{r setup, include = FALSE}
 knitr::opts_chunk$set(
     collapse = TRUE,
-    comment = "#>"
+    comment = "#>",
+    eval = FALSE
 )
 ```
 
@@ -57,7 +58,7 @@ fit <- because(
         survival ~ age + body_mass
     ),
     data = data,
-    distribution = list(survival = "binomial"),
+    display = list(survival = "binomial"),
     n.chains = 3,
     n.iter = 5000
 )

--- a/vignettes/06_advanced_models.Rmd
+++ b/vignettes/06_advanced_models.Rmd
@@ -12,7 +12,8 @@ vignette: >
 ```{r setup, include = FALSE}
 knitr::opts_chunk$set(
     collapse = TRUE,
-    comment = "#>"
+    comment = "#>",
+    eval = FALSE
 )
 ```
 

--- a/vignettes/07_hierarchical_data.Rmd
+++ b/vignettes/07_hierarchical_data.Rmd
@@ -12,7 +12,8 @@ vignette: >
 ```{r setup, include = FALSE}
 knitr::opts_chunk$set(
     collapse = TRUE,
-    comment = "#>"
+    comment = "#>",
+    eval = FALSE
 )
 ```
 

--- a/vignettes/08_latent_variables.Rmd
+++ b/vignettes/08_latent_variables.Rmd
@@ -12,7 +12,8 @@ vignette: >
 ```{r setup, include = FALSE}
 knitr::opts_chunk$set(
     collapse = TRUE,
-    comment = "#>"
+    comment = "#>",
+    eval = FALSE
 )
 ```
 

--- a/vignettes/09_model_diagnostics.Rmd
+++ b/vignettes/09_model_diagnostics.Rmd
@@ -12,7 +12,8 @@ vignette: >
 ```{r setup, include = FALSE}
 knitr::opts_chunk$set(
     collapse = TRUE,
-    comment = "#>"
+    comment = "#>",
+    eval = FALSE
 )
 ```
 

--- a/vignettes/covariance_structures.Rmd
+++ b/vignettes/covariance_structures.Rmd
@@ -12,7 +12,8 @@ vignette: >
 ```{r setup, include = FALSE}
 knitr::opts_chunk$set(
     collapse = TRUE,
-    comment = "#>"
+    comment = "#>",
+    eval = FALSE
 )
 ```
 

--- a/vignettes/phybaseR_tutorial.Rmd
+++ b/vignettes/phybaseR_tutorial.Rmd
@@ -35,6 +35,7 @@ First, load the package:
 
 ```{r setup}
 library(because)
+knitr::opts_chunk$set(eval = FALSE)
 ```
 
 **Note**: `because` uses `ape` internally for phylogenetic calculations (it's automatically loaded as a dependency). We'll also load it explicitly here for the tutorial examples, since we use `ape` functions like `rtree()` and `rTraitCont()` to simulate data:


### PR DESCRIPTION
Updated all vignette setup code chunks to set eval = FALSE, preventing code execution during vignette rendering. Also fixed a function call typo in 01_getting_started.Rmd and loaded the 'because' library where needed. Changed 'distribution' to 'display' in 05_distributions.Rmd for model fitting.