### PR TITLE
Fix knitr chunk options function name in vignette

### DIFF
--- a/vignettes/01_getting_started.Rmd
+++ b/vignettes/01_getting_started.Rmd
@@ -13,7 +13,7 @@ editor_options:
 ---
 
 ```{r setup, include = FALSE}
-knitr::opts_chunk_set(
+knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
   eval = FALSE


### PR DESCRIPTION
Replaces incorrect use of `opts_chunk_set` with the correct `opts_chunk$set` in the vignette setup chunk to ensure proper configuration of knitr options.